### PR TITLE
Add colorscheme for nord

### DIFF
--- a/autoload/crystalline/theme/nord.vim
+++ b/autoload/crystalline/theme/nord.vim
@@ -1,0 +1,24 @@
+function! crystalline#theme#nord#set_theme() abort
+  if get(g:, 'nord_uniform_status_lines')
+    let inactive8 = [189, 239]
+    let inactive24 = ['#E5E9F0', '#4C566A']
+  else
+    let inactive8 = [189, 238]
+    let inactive24 = ['#E5E9F0', '#3B4252']
+  endif
+  call crystalline#generate_theme({
+        \ 'NormalMode':  [[238, 110], ['#3B4252', '#88C0D0']],
+        \ 'InsertMode':  [[238, 231], ['#3B4252', '#ECEFF4']],
+        \ 'VisualMode':  [[238, 108], ['#3B4252', '#8FBCBB']],
+        \ 'ReplaceMode': [[238, 222], ['#3B4252', '#EBCB8B']],
+        \ '':            [[189, 238], ['#E5E9F0', '#3B4252']],
+        \ 'Inactive':    [inactive8, inactive24],
+        \ 'Fill':        [[189, 239], ['#E5E9F0', '#4C566A']],
+        \ 'Tab':         [[189, 239], ['#E5E9F0', '#4C566A']],
+        \ 'TabType':     [[238, 109], ['#3B4252', '#81A1C1']],
+        \ 'TabSel':      [[238, 110], ['#3B4252', '#88C0D0']],
+        \ 'TabFill':     [[189, 239], ['#E5E9F0', '#4C566A']],
+        \ })
+endfunction
+
+" vim:set et sw=2 ts=2 fdm=marker:


### PR DESCRIPTION
[Nord][] is my favorite coloscheme. I ported crystalline for it.

[Nord]: https://www.nordtheme.com/ports/vim

* 24bit color

   <img width="799" alt="スクリーンショット 0001-10-26 10 50 14" src="https://user-images.githubusercontent.com/1239245/67612533-7177fc80-f7de-11e9-8345-1eb3e392bf98.png">

* 8bit color

   <img width="798" alt="スクリーンショット 0001-10-26 10 49 52" src="https://user-images.githubusercontent.com/1239245/67612535-79d03780-f7de-11e9-8c5c-4d500d3e6c79.png">

Note: Nord supports 24bit color only, so 8bit colors in this PR are my personal choices.