### PR TITLE
Add support for custom highlight groups

### DIFF
--- a/autoload/crystalline.vim
+++ b/autoload/crystalline.vim
@@ -332,11 +332,7 @@ function! crystalline#generate_theme(theme) abort
 
   let g:crystalline_tab_type_fake_separators = []
 
-  for l:group in g:crystalline_hi_groups
-    let l:attr = get(a:theme, l:group, [])
-    if l:attr == []
-      continue
-    endif
+  for [l:group, l:attr] in items(a:theme)
     let l:his += [crystalline#generate_hi(l:group, l:attr)]
 
     if !get(g:, 'crystalline_enable_sep', 0)

--- a/plugin/crystalline.vim
+++ b/plugin/crystalline.vim
@@ -39,20 +39,6 @@ if get(g:, 'crystalline_enable_sep', 0)
   endif
 endif
 
-let g:crystalline_hi_groups = [
-        \ 'NormalMode',
-        \ 'InsertMode',
-        \ 'VisualMode',
-        \ 'ReplaceMode',
-        \ '',
-        \ 'Inactive',
-        \ 'Fill',
-        \ 'Tab',
-        \ 'TabType',
-        \ 'TabSel',
-        \ 'TabFill',
-        \ ]
-
 if !exists('g:crystalline_separators')
   let g:crystalline_separators = ['', '']
 endif


### PR DESCRIPTION
This PR allows for themes to add their own highlight groups on top of the default ones. It does so by iterating over the theme dictionary's items instead of using `g:crystalline_hi_groups`. Thus, `g:crystalline_hi_groups` doesn't serve a purpose and can be deleted.

Note that even before this PR, a theme was not required to implement the default highlight groups anyways: If it didn't have an entry for a group's name, `crystalline#generate_theme()` would simply skip generating a highlight group for this name and continue with the next one.

Also note that, if a user wants to generate separator highlight groups for the custom groups in a theme, they will need to add mappings to `g:crystalline_supported_sep`.

This is the first part of a fix for #17. The second part (in a later PR) will add support for overriding a theme's highlight groups with ad-hoc highlight groups.