### PR TITLE
Create separator highlight groups dynamically

### DIFF
--- a/autoload/crystalline.vim
+++ b/autoload/crystalline.vim
@@ -314,6 +314,69 @@ function! crystalline#get_sep_group(group_a, group_b) abort
   return a:group_a . 'To' . (a:group_b ==# '' ? 'Line' : a:group_b)
 endfunction
 
+" Returns a dictionary with attributes of a highlight group.
+" Returns an empty dictionary if the highlight group doesn't exist.
+function! crystalline#synIDattrs(hlgroup) abort
+  let l:id = synIDtrans(hlID(a:hlgroup))
+  if !l:id
+    return {}
+  endif
+
+  let l:result = {}
+  let l:modes = ['term','cterm', 'gui']
+  let l:colors = ['fg', 'bg', 'sp']
+  let l:attrs = ['font', 'bold', 'italic', 'reverse', 'inverse', 'standout', 'underline', 'undercurl', 'strikethrough']
+
+  for l:mode in l:modes
+    let l:result[l:mode] = {}
+    let l:result[l:mode]['attrs'] = []
+
+    for l:attr in l:attrs
+      if synIDattr(l:id, l:attr, l:mode)
+        call add(l:result[l:mode].attrs, l:attr)
+      endif
+    endfor
+
+    " term mode has no colors
+    if l:mode == 'term'
+      continue
+    endif
+
+    for l:color in l:colors
+      " cterm mode has no sp color
+      if l:color == 'sp'
+        continue
+      endif
+      let l:res_color = synIDattr(l:id, l:color, l:mode)
+      let l:result[l:mode][l:color] = !empty(l:res_color) ? l:res_color : 'NONE'
+    endfor
+  endfor
+
+  return l:result
+endfunction
+
+" Translates crystalline#synIDattrs() into the format
+" crystalline#generate_hi() understands.
+function! crystalline#get_hl_attrs(group) abort
+  let l:attrs = crystalline#synIDattrs('Crystalline' . a:group)
+  if l:attrs == {}
+    return []
+  endif
+  let l:retval = [[l:attrs.cterm.fg, l:attrs.cterm.bg], [l:attrs.gui.fg, l:attrs.gui.bg]]
+
+  let l:retval_attrs = []
+  for l:mode in keys(l:attrs)
+    if !empty(l:attrs[l:mode].attrs)
+      call add(l:retval_attrs, l:mode . '=' . join(l:attrs[l:mode].attrs, ','))
+    endif
+  endfor
+  if !empty(l:retval_attrs)
+    call add(l:retval, join(l:retval_attrs, ' '))
+  endif
+
+  return l:retval
+endfunction
+
 function! crystalline#generate_hi(group, attr) abort
   let l:cterm = a:attr[0]
   let l:gui = a:attr[1]
@@ -339,7 +402,6 @@ function! crystalline#generate_theme(theme) abort
   if len(l:his) > 0
     exec join(l:his, ' | ')
   endif
-  let g:crystalline_theme_config = copy(a:theme)
 endfunction
 
 function! crystalline#mode_hi() abort
@@ -347,8 +409,8 @@ function! crystalline#mode_hi() abort
 endfunction
 
 function! crystalline#generate_sep_hi(group_a, group_b) abort
-  let l:attr_a = g:crystalline_theme_config[a:group_a]
-  let l:attr_b = g:crystalline_theme_config[a:group_b]
+  let l:attr_a = crystalline#get_hl_attrs(a:group_a)
+  let l:attr_b = crystalline#get_hl_attrs(a:group_b)
   let l:sep_attr = [[l:attr_a[0][1], l:attr_b[0][1]], [l:attr_a[1][1], l:attr_b[1][1]]]
   if len(l:attr_a) > 2
     let l:sep_attr += [l:attr_a[2]]

--- a/autoload/crystalline.vim
+++ b/autoload/crystalline.vim
@@ -426,6 +426,7 @@ function! crystalline#generate_sep_hi(group_a, group_b) abort
   let l:sep_group = crystalline#get_sep_group(a:group_a, a:group_b)
 
   exec crystalline#generate_hi(l:sep_group, l:sep_attr)
+  let g:crystalline_sep_hi_groups[l:sep_group] = l:sep_attr
 endfunction
 
 function! crystalline#sep(group_a, group_b, ch, left) abort
@@ -524,6 +525,11 @@ function! crystalline#apply_current_theme() abort
   catch /^Vim\%((\a\+)\)\=:E118/
     " theme does not use autoload function
   endtry
+
+  call crystalline#generate_theme(g:crystalline_sep_hi_groups)
+  " Empty out after adjusting separator HGs
+  let g:crystalline_sep_hi_groups = {}
+
   silent doautocmd User CrystallineSetTheme
 endfunction
 

--- a/autoload/crystalline.vim
+++ b/autoload/crystalline.vim
@@ -426,7 +426,6 @@ function! crystalline#generate_sep_hi(group_a, group_b) abort
   let l:sep_group = crystalline#get_sep_group(a:group_a, a:group_b)
 
   exec crystalline#generate_hi(l:sep_group, l:sep_attr)
-  let g:crystalline_sep_hi_groups[l:sep_group] = l:sep_attr
 endfunction
 
 function! crystalline#sep(group_a, group_b, ch, left) abort
@@ -440,13 +439,14 @@ function! crystalline#sep(group_a, group_b, ch, left) abort
   if a:left == 0 && a:group_a ==# 'TabType' && index(get(g:, 'crystalline_tab_type_fake_separators', []), a:group_b) >= 0
     let l:sep_item = g:crystalline_tab_separator
   else
-    let l:sep_group = crystalline#get_sep_group(a:group_a, a:group_b)
+    let l:sep_group = 'Crystalline' . crystalline#get_sep_group(a:group_a, a:group_b)
     " Create if it doesn't exist
-    if !hlexists(l:sep_group)
+    if !has_key(g:crystalline_sep_hi_groups, l:sep_group)
       call crystalline#generate_sep_hi(a:group_a, a:group_b)
+      let g:crystalline_sep_hi_groups[l:sep_group] = [a:group_a, a:group_b]
     endif
 
-    let l:sep_item = '%#Crystalline' . l:sep_group . '#' . a:ch
+    let l:sep_item = '%#' . l:sep_group . '#' . a:ch
   endif
   return l:sep_item . l:next_item
 endfunction
@@ -526,8 +526,6 @@ function! crystalline#apply_current_theme() abort
     " theme does not use autoload function
   endtry
 
-  call crystalline#generate_theme(g:crystalline_sep_hi_groups)
-  " Empty out after adjusting separator HGs
   let g:crystalline_sep_hi_groups = {}
 
   silent doautocmd User CrystallineSetTheme

--- a/doc/crystalline.txt
+++ b/doc/crystalline.txt
@@ -67,22 +67,6 @@ The setting must be a list of strings, with the first string representing the
 right-facing separator and the second string representing the left-facing
 separator.
 
-g:crystalline_supported_sep                  *g:crystalline_supported_sep*
-
-Additional highlight groups for which crystalline should generate separators.
-Crystalline doesn't generate all possible separators by default to improve
-performance.
-
-For example, if you want to use separators between the highlight groups
-"CrystallineFill" and "Crystalline", and between "CrystallineFill" and
-"CrystallineTabSel" (neither of which are defined by default):
-
->
-  let g:crystalline_supported_sep = {
-  \ 'Fill': ['', 'TabSel']
-  }
-<
-
 g:crystalline_tab_separator                     *g:crystalline_tab_separator*
 
 The separator character(s) to use between unselected tabs. By default, it will

--- a/plugin/crystalline.vim
+++ b/plugin/crystalline.vim
@@ -18,27 +18,6 @@ let g:crystalline_mode_hi_groups = {
       \ '': '',
       \ }
 
-if get(g:, 'crystalline_enable_sep', 0)
-  let g:crystalline_default_supported_sep = {
-        \ 'NormalMode': ['', 'Fill', 'TabFill', 'Tab'],
-        \ 'InsertMode': ['', 'Fill', 'TabFill', 'Tab'],
-        \ 'VisualMode': ['', 'Fill', 'TabFill', 'Tab'],
-        \ 'ReplaceMode': ['', 'Fill', 'TabFill', 'Tab'],
-        \ '': ['Fill'],
-        \ 'Inactive': [],
-        \ 'Fill': [],
-        \ 'Tab': ['TabSel', 'TabFill', 'NormalMode', 'InsertMode', 'VisualMode', 'ReplaceMode'],
-        \ 'TabType': ['Tab', 'TabSel', 'TabFill', 'NormalMode', 'InsertMode', 'VisualMode', 'ReplaceMode'],
-        \ 'TabSel': ['Tab', 'TabFill'],
-        \ 'TabFill': [],
-        \ }
-  if exists('g:crystalline_supported_sep')
-    call extend(g:crystalline_supported_sep, g:crystalline_default_supported_sep, 'keep')
-  else
-    let g:crystalline_supported_sep = copy(g:crystalline_default_supported_sep)
-  endif
-endif
-
 if !exists('g:crystalline_separators')
   let g:crystalline_separators = ['', '']
 endif

--- a/plugin/crystalline.vim
+++ b/plugin/crystalline.vim
@@ -42,6 +42,10 @@ if !exists('g:crystalline_tab_nomod')
   let g:crystalline_tab_nomod = ' '
 endif
 
+if !exists('g:crystalline_sep_hi_groups')
+  let g:crystalline_sep_hi_groups = {}
+endif
+
 " }}}
 
 " Load User Settings {{{

--- a/plugin/crystalline.vim
+++ b/plugin/crystalline.vim
@@ -69,6 +69,7 @@ endif
 augroup CrystallineTheme
   au!
   au ColorScheme * call crystalline#apply_current_theme()
+  au OptionSet background call crystalline#apply_current_theme()
 augroup END
 
 " }}}

--- a/t/crystalline.vim
+++ b/t/crystalline.vim
@@ -221,6 +221,19 @@ describe 'crystalline#sep'
     hi CrystallineFillToLine
   end
 
+  it 'dynamically creates separator highlight groups'
+    let g:crystalline_enable_sep = 1
+    hi CrystallineTestGroupA ctermfg=1 ctermbg=2 guifg=#111111 guibg=#222222
+    hi CrystallineTestGroupB ctermfg=3 ctermbg=4 guifg=#333333 guibg=#444444
+    Expect crystalline#sep('TestGroupA', 'TestGroupB', '>', 0) ==# '%#CrystallineTestGroupAToTestGroupB#>%#CrystallineTestGroupB#'
+    hi CrystallineTestGroupAToTestGroupB
+    let attrs =  crystalline#synIDattrs('CrystallineTestGroupAToTestGroupB')
+    Expect attrs.cterm.fg == '2'
+    Expect attrs.cterm.bg == '4'
+    Expect attrs.gui.fg == '#222222'
+    Expect attrs.gui.bg == '#444444'
+  end
+
 end
 
 describe 'crystalline#bufferline'

--- a/t/crystalline.vim
+++ b/t/crystalline.vim
@@ -90,24 +90,6 @@ describe 'g:crystalline_theme'
     hi CrystallineTabSel
     hi CrystallineTabFill
   end
-
-  it 'defines basic separator groups'
-    let g:crystalline_enable_sep = 1
-    source plugin/crystalline.vim
-    hi CrystallineNormalModeToLine
-    hi CrystallineNormalModeToTab
-    hi CrystallineNormalModeToTabFill
-    hi CrystallineToFill
-    hi CrystallineTabTypeToTab
-    hi CrystallineTabTypeToTabSel
-    hi CrystallineTabTypeToTabFill
-    hi CrystallineTabTypeToNormalMode
-    hi CrystallineTabSelToTab
-    hi CrystallineTabSelToTabFill
-    hi CrystallineTabToTabSel
-    hi CrystallineTabToTabFill
-    hi CrystallineTabToNormalMode
-  end
 end
 
 describe 'g:crystalline_*_separator(s)'
@@ -230,6 +212,15 @@ describe 'crystalline#sep'
     Expect crystalline#sep('', 'Fill', '>', 0) ==# '%#CrystallineToFill#>%#CrystallineFill#'
     Expect crystalline#sep('', 'Fill', '<', 1) ==# '%#CrystallineToFill#<%#Crystalline#'
   end
+
+  it 'automatically creates nonexistent separator highlight groups'
+    let g:crystalline_enable_sep = 1
+    Expect crystalline#sep('', 'Fill', '>', 0) ==# '%#CrystallineToFill#>%#CrystallineFill#'
+    Expect crystalline#sep('Fill', '', '>', 0) ==# '%#CrystallineFillToLine#>%#Crystalline#'
+    hi CrystallineToFill
+    hi CrystallineFillToLine
+  end
+
 end
 
 describe 'crystalline#bufferline'


### PR DESCRIPTION
With this PR, `generate_theme()` will not create highlight groups for separators anymore. They will instead be created on the fly if they don't exist, making `g:crystalline_supported_sep` unnecessary.

The `crystalline#generate_theme()` function now exposes its `a:theme` argument as `g:crystalline_theme_config`. We use that to create the separator highlighting groups. An alternative way would be to use something like `synIDattr(synIDtrans(hlID('CrystallineFill')), 'bg', 'gui')` which only returns a single attribute per call. I haven't benchmarked which is faster, though.)