### PR TITLE
crystalline#left_sep(): Fix argument order

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ set laststatus=2
 function! StatusLine(...)
   return crystalline#mode() . crystalline#right_mode_sep('')
         \ . ' %f%h%w%m%r ' . crystalline#right_sep('', 'Fill') . '%='
-        \ . crystalline#left_sep('', 'Fill') . ' %{&ft}[%{&fenc!=#""?&fenc:&enc}][%{&ff}] %l/%L %c%V %P '
+        \ . crystalline#left_sep('Fill', '') . ' %{&ft}[%{&fenc!=#""?&fenc:&enc}][%{&ff}] %l/%L %c%V %P '
 endfunction
 let g:crystalline_enable_sep = 1
 let g:crystalline_statusline_fn = 'StatusLine'
@@ -231,7 +231,7 @@ function! StatusLine(current, width)
 
   let l:s .= '%='
   if a:current
-    let l:s .= crystalline#left_sep('', 'Fill') . ' %{&paste ?"PASTE ":""}%{&spell?"SPELL ":""}'
+    let l:s .= crystalline#left_sep('Fill', '') . ' %{&paste ?"PASTE ":""}%{&spell?"SPELL ":""}'
     let l:s .= crystalline#left_mode_sep('')
   endif
   if a:width > 80

--- a/autoload/crystalline.vim
+++ b/autoload/crystalline.vim
@@ -400,7 +400,7 @@ function! crystalline#right_sep(group_a, group_b) abort
 endfunction
 
 function! crystalline#left_sep(group_a, group_b) abort
-  return crystalline#sep(a:group_a, a:group_b, g:crystalline_separators[1], 1)
+  return crystalline#sep(a:group_b, a:group_a, g:crystalline_separators[1], 1)
 endfunction
 
 function! crystalline#right_mode_sep(group) abort

--- a/doc/crystalline.txt
+++ b/doc/crystalline.txt
@@ -123,11 +123,22 @@ Generate a right-facing separator between the two highlight groups.
 Use the group names listed in |crystaline-highlight-groups|, with
 "Crystalline" omitted.
 
+The highlight group that is used for this separator will have the name
+"Crystalline" . group_a . "To" . group_b. For example, if you create a
+separator with crystalline#right_sep('Inactive', 'Fill'), the highlight group
+for this separator will be called "CrystallineInactiveToFill".
+
 crystalline#left_sep(group_a, group_b)          *crystalline#left_sep()*
 
 Generate a left-facing separator between the two highlight groups.
 
-See |crystalline#right_sep()|.
+The highlight group that is used for this separator will have the name
+"Crystalline" . group_b . "To" . group_b. For example, if you create a
+separator with crystalline#left_sep('Inactive', 'Fill'), the highlight group
+for this separator will be called "CrystallineFillToInactive".
+
+Note: the order of the highlight group names is reversed from
+|crystalline#right_sep()|.
 
 crystalline#right_mode_sep(group)               *crystalline#right_mode_sep()*
 
@@ -240,7 +251,7 @@ EXAMPLE                                         *crystalline-example*
 
     let l:s .= '%='
     if a:current
-      let l:s .= crystalline#left_sep('', 'Fill') . ' %{&paste ?"PASTE ":""}%{&spell?"SPELL ":""}'
+      let l:s .= crystalline#left_sep('Fill', '') . ' %{&paste ?"PASTE ":""}%{&spell?"SPELL ":""}'
       let l:s .= crystalline#left_mode_sep('')
     endif
     if a:width > 80


### PR DESCRIPTION
The order for the highlight groups was confusing me a *lot*. In essence, `left_sep()` required you to write the group that comes *after* the separator *first*.

This patch simply changes the order of the arguments to `left_sep()` and (hopefully) fixes all uses of `left_sep()` in the documentation.

The fact that the same highlight group is used for both `left_sep()` and `right_sep()` might trip up some users, so I've also added a note to the documentation.