### PR TITLE
Expose g:crystalline_mode_labels as an option

### DIFF
--- a/doc/crystalline.txt
+++ b/doc/crystalline.txt
@@ -48,6 +48,15 @@ g:crystalline_theme                             *g:crystalline_theme*
 
 Automatically set the given theme.
 
+g:crystalline_mode_labels                       *g:crystalline_mode_labels*
+
+The labels to use for the different modes. By default, it will be the
+capitalized full name of each mode.
+
+The setting must be a dictionary of strings, with the key representing the
+different modes ('n', 'i', 'v' and 'R') and the value representing the label
+for each mode.
+
 g:crystalline_enable_sep                        *g:crystalline_enable_sep*
 
 Enable using special separator symbols between sections/tabs, similar to

--- a/plugin/crystalline.vim
+++ b/plugin/crystalline.vim
@@ -2,13 +2,15 @@ scriptencoding utf-8
 
 " Helper Variables {{{
 
-let g:crystalline_mode_labels = {
-      \ 'n': ' NORMAL ',
-      \ 'i': ' INSERT ',
-      \ 'v': ' VISUAL ',
-      \ 'R': ' REPLACE ',
-      \ '': '',
-      \ }
+if !exists('g:crystalline_mode_labels')
+  let g:crystalline_mode_labels = {
+        \ 'n': ' NORMAL ',
+        \ 'i': ' INSERT ',
+        \ 'v': ' VISUAL ',
+        \ 'R': ' REPLACE ',
+        \ '': '',
+        \ }
+endif
 
 let g:crystalline_mode_hi_groups = {
       \ 'n': 'NormalMode',

--- a/t/crystalline.vim
+++ b/t/crystalline.vim
@@ -23,6 +23,7 @@ function! CleanCrystalline()
   unlet! g:crystalline_mode
   unlet! g:crystalline_separators
   unlet! g:crystalline_tab_separator
+  unlet! g:crystalline_mode_labels
   call crystalline#clear_statusline()
   call crystalline#clear_tabline()
   call crystalline#clear_theme()
@@ -116,6 +117,39 @@ describe 'g:crystalline_*_separator(s)'
     source plugin/crystalline.vim
     Expect g:crystalline_separators == ['>', '<']
     Expect g:crystalline_tab_separator ==# '-'
+  end
+end
+
+describe 'g:crystalline_mode_labels'
+  after
+    call CleanCrystalline()
+  end
+
+  it 'sets the default mode labels'
+    source plugin/crystalline.vim
+    Expect g:crystalline_mode_labels == {
+          \ 'n': ' NORMAL ',
+          \ 'i': ' INSERT ',
+          \ 'v': ' VISUAL ',
+          \ 'R': ' REPLACE ',
+          \ '': '',
+          \ }
+  end
+
+  it 'allows overriding mode labels'
+    let g:crystalline_mode_labels = {
+          \ 'n': ' N ',
+          \ 'v': ' V ',
+          \ 'i': ' I ',
+          \ 'R': ' R ',
+          \ }
+    source plugin/crystalline.vim
+    Expect g:crystalline_mode_labels == {
+          \ 'n': ' N ',
+          \ 'v': ' V ',
+          \ 'i': ' I ',
+          \ 'R': ' R ',
+          \ }
   end
 end
 


### PR DESCRIPTION
This PR allows the user to optionally set `g:crystalline_mode_labels`.

Example usage:
```vim
let g:crystalline_mode_labels = {
      \ 'n': ' N ',
      \ 'v': ' V ',
      \ 'i': ' I ',
      \ 'R': ' R ',
      \ }
```
```vim
let g:crystalline_mode_labels = {
      \ 'n': ' ◇ ',
      \ 'v': ' ◆ ',
      \ 'i': ' △ ',
      \ 'R': ' ▲ ',
      \ }
```

Tests and documentation have been added accordingly. Default mode labels remain the same.
Feedback is appreciated!