### PR TITLE
Add `g:crystalline_hide_tab_header` option

### DIFF
--- a/autoload/crystalline.vim
+++ b/autoload/crystalline.vim
@@ -256,6 +256,7 @@ endfunction
 
 function! crystalline#bufferline(...) abort
   let l:enable_sep = get(g:, 'crystalline_enable_sep', 0)
+  let l:hide_head = get(g:, 'crystalline_hide_tab_header', 0)
   let l:use_buffers = tabpagenr('$') == 1
 
   let l:items = get(a:, 1, 0)
@@ -286,6 +287,8 @@ function! crystalline#bufferline(...) abort
     let [l:tabs, l:ntabs, l:curtab] = crystalline#tabinfo(l:maxtabs)
     let l:tabline = '%#CrystallineTabType# TABS '
   endif
+
+  let l:tabline = ( l:hide_head ? '' : l:tabline )
 
   let [l:vtabs, l:vntabs, l:vcurtab] = crystalline#visual_tabinfo(l:tabs, l:curtab, l:ntabs, l:pad, l:tabpad, l:tabwidth, l:tablabel)
   let l:tabline .= crystalline#tab_sep(0, l:vcurtab, l:vntabs, l:show_mode)

--- a/doc/crystalline.txt
+++ b/doc/crystalline.txt
@@ -81,6 +81,10 @@ g:crystalline_tab_separator                     *g:crystalline_tab_separator*
 The separator character(s) to use between unselected tabs. By default, it will
 use the powerline-style separator.
 
+g:crystalline_hide_tab_header                   *g:crystalline_hide_tab_header*
+
+Force the hide of the tabline header.
+
 g:crystalline_hide_buf_tab                      *g:crystalline_hide_buf_tab*
 
 The name of a function to determine if a buffer should be hidden from tabline


### PR DESCRIPTION
Hide the header in the tabline. Default is not modified.

I think this can be useful if you want only hide this without rebuild the whole tabline.