### PR TITLE
Update for changes to fugitive.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ set laststatus=2
 
 ```vim
 function! StatusLine(...)
-  return ' %f%h%w%m%r %{fugitive#head()} %{&paste ?"PASTE ":""}%{&spell?"SPELL ":""}'
+  return ' %f%h%w%m%r %{FugitiveHead()} %{&paste ?"PASTE ":""}%{&spell?"SPELL ":""}'
 endfunction
 let g:crystalline_statusline_fn = 'StatusLine'
 set laststatus=2
@@ -226,7 +226,7 @@ function! StatusLine(current, width)
   endif
   let l:s .= ' %f%h%w%m%r '
   if a:current
-    let l:s .= crystalline#right_sep('', 'Fill') . ' %{fugitive#head()}'
+    let l:s .= crystalline#right_sep('', 'Fill') . ' %{FugitiveHead()}'
   endif
 
   let l:s .= '%='

--- a/doc/crystalline.txt
+++ b/doc/crystalline.txt
@@ -286,7 +286,7 @@ EXAMPLE                                         *crystalline-example*
     endif
     let l:s .= ' %f%h%w%m%r '
     if a:current
-      let l:s .= crystalline#right_sep('', 'Fill') . '%{fugitive#head()}'
+      let l:s .= crystalline#right_sep('', 'Fill') . '%{FugitiveHead()}'
     endif
 
     let l:s .= '%='


### PR DESCRIPTION
fugitive.vim has deprecated calls to fugitive#head.

See: https://github.com/tpope/vim-fugitive/commit/b81c59bd6adb2a1aac7d3865eb4ee0f6e51eb29c
